### PR TITLE
Removed SDK hotkey and using event hotkey

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,11 +32,6 @@ exports.main = function (options, callbacks) {
     // Determine OS
     platform = system.platform;
 
-    if (platform == 'darwin')
-        keyCombo = '(Control + ' + key + ' )';
-    else
-        keyCombo = '(Ctrl + ' + key + ' )';
-
     // Init button
     button = buttons.ActionButton({
         id: 'stay-on-top',
@@ -117,7 +112,12 @@ var windowListener = {
 function hotkeyPress(e) {
     console.error('in keypress, e.key:', e.key);
     if (e.key.toLowerCase() == key) {
-        handleClick(null);
+        if (platform == 'darwin' && e.metaKey) {
+        	handleClick(null);
+        } else if (e.ctrlKey) {
+        	handleClick(null);
+        }
+        
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function initHotkey() {
     });
 }
 
-function hotkeyPress = function(e) {
+function hotkeyPress(e) {
     if (e.key.toLowerCase() == key) {
         handleClick(null);
     }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var ostypes = {};
 var toggleHotkey;
 var keyCombo;
 
-var key '`';
+var key = '`';
 
 /**
  * Runs at installation/program start

--- a/index.js
+++ b/index.js
@@ -62,14 +62,15 @@ exports.main = function (options, callbacks) {
     sot_initCtypes();
 };
 
+var { viewFor } = require("sdk/view/core");
 function initHotkey() {
     var windows = require("sdk/windows");
     for (let window of windows.browserWindows) {
-        window.addEventListener('keyup', hotkeyPress, false);
+        viewFor(window).addEventListener('keyup', hotkeyPress, false);
     }
     
     windows.on('open', function(window) {
-        window.addEventListener('keyup', hotkeyPress, false);
+        viewFor(window).addEventListener('keyup', hotkeyPress, false);
     });
 }
 
@@ -82,7 +83,7 @@ function hotkeyPress = function(e) {
 function uninitHotkey() {
     var windows = require("sdk/windows");
     for (let window of windows.browserWindows) {
-        window.removeEventListener('keyup', hotkeyPress, false);
+        viewFor(window).removeEventListener('keyup', hotkeyPress, false);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ var ostypes = {};
 var toggleHotkey;
 var keyCombo;
 
+var key '`';
+
 /**
  * Runs at installation/program start
  * @param options
@@ -31,9 +33,9 @@ exports.main = function (options, callbacks) {
     platform = system.platform;
 
     if (platform == 'darwin')
-        keyCombo = '(Control + ` )';
+        keyCombo = '(Control + ' + key + ' )';
     else
-        keyCombo = '(CTRL+` )';
+        keyCombo = '(Ctrl + ' + key + ' )';
 
     // Init button
     button = buttons.ActionButton({
@@ -55,9 +57,34 @@ exports.main = function (options, callbacks) {
             handleClick(null);
         }
     });
+    initHotkey();
 
     sot_initCtypes();
 };
+
+function initHotkey() {
+    var windows = require("sdk/windows");
+    for (let window of windows.browserWindows) {
+        window.addEventListener('keyup', hotkeyPress, false);
+    }
+    
+    windows.on('open', function(window) {
+        window.addEventListener('keyup', hotkeyPress, false);
+    });
+}
+
+function hotkeyPress = function(e) {
+    if (e.key.toLowerCase() == key) {
+        handleClick(null);
+    }
+}
+
+function uninitHotkey() {
+    var windows = require("sdk/windows");
+    for (let window of windows.browserWindows) {
+        window.removeEventListener('keyup', hotkeyPress, false);
+    }
+}
 
 /**
  * Runs at uninstallation/program end
@@ -70,7 +97,7 @@ exports.unload = function (reason) {
         }
     }
 
-    toggleHotkey.destroy();
+    uninitHotkey();
 };
 
 /**


### PR DESCRIPTION
This should address issue #5 and allow the hotkey to work from non-`navigator:browser` type windows. So hotkey from Browser Console window and etc should work now. Untested.